### PR TITLE
remove mupdf-third which is not in MacPorts anymore

### DIFF
--- a/qpdfview.sh
+++ b/qpdfview.sh
@@ -61,7 +61,7 @@ compile_bundle() {
   fi
 
   if [ "$FITZ_PLUGIN_LIBS" = "" ]; then
-    FITZ_PLUGIN_LIBS="-lmupdf -lmupdf-third -lfreetype -lharfbuzz -lz -ljpeg -ljbig2dec -lopenjp2"
+    FITZ_PLUGIN_LIBS="-lmupdf -lfreetype -lharfbuzz -lz -ljpeg -ljbig2dec -lopenjp2"
   fi
 
   qmake APP_DIR_DATA_PATH=../Resources CONFIG+=with_fitz \


### PR DESCRIPTION
I found in this PyMuPDF issue that mupdf-third might not be shipped by default, and indeed I could not find mupdf-third in MacPorts. There was an error running qpdfview.sh when trying to use it: "ld: library not found for -lmupdf-third"

https://github.com/pymupdf/PyMuPDF/issues/1396#issuecomment-967229261

I have 1.19.0 in MacPorts on this machine.

$ mupdf-gl -h
mupdf-gl: unknown option -h
mupdf-gl version 1.19.0
usage: mupdf-gl [options] document [page]
...

QPDFView works just fine for me without mupdf-third, at least as far as all the PDFs I've checked.